### PR TITLE
GitHub ActionsのCI/CDワークフローを追加し、Mavenビルドとテストカバレッジのチェックを設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+permissions:
+    contents: write
+    security-events: write
+
+name: Continuous Integration
+
+on:
+    push:
+        branches: ["main"]
+    pull_request:
+        branches: ["main"]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up JDK 21
+              uses: actions/setup-java@v4
+              with:
+                  java-version: "21"
+                  distribution: "temurin"
+                  cache: maven
+
+            - name: Build with Maven
+              run: mvn -B package --file pom.xml
+
+            - name: Check Test Coverage
+              run: |
+                  COVERAGE=$(mvn jacoco:report | grep -A 1 "Total.*class" | grep "[0-9]\{1,3\}%" | grep -o "[0-9]\{1,3\}%" | cut -d'%' -f1)
+                  if [ "$COVERAGE" -lt 100 ]; then
+                    echo "Test coverage is below 100%. Current coverage: $COVERAGE%"
+                    exit 1
+                  else
+                    echo "Test coverage is 100%"
+                  fi
+
+            - name: Upload coverage report
+              uses: actions/upload-artifact@v4
+              with:
+                  name: coverage-report
+                  path: target/site/jacoco/
+
+            - name: Update dependency graph
+              uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+    release:
+        types: [created]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up JDK 21
+              uses: actions/setup-java@v4
+              with:
+                  java-version: "21"
+                  distribution: "temurin"
+                  server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+                  settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+            - name: Build with Maven
+              run: mvn -B package --file pom.xml
+
+            - name: Publish to GitHub Packages Apache Maven
+              run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
このプル リクエストでは、継続的インテグレーションと Maven パッケージ公開プロセスを自動化する 2 つの新しい GitHub Actions ワークフローが導入されています。最も重要な変更には、メイン ブランチへのプッシュとプル リクエストで実行される CI ワークフローの設定と、リリース作成時にパッケージを公開する Maven パッケージ ワークフローの構成が含まれます。

### 継続的インテグレーション ワークフロー:

* `main` ブランチへのプッシュとプル リクエストでトリガーされる新しい CI ワークフローを追加しました。JDK 21 を設定し、Maven でビルドし、テスト カバレッジをチェックし、カバレッジ レポートをアップロードします。(`.github/workflows/ci.yml`)

### Maven パッケージ公開ワークフロー:

* リリース作成時にトリガーされる新しい Maven パッケージ ワークフローを追加しました。JDK 21 を設定し、Maven を使用してパッケージを GitHub パッケージに公開します。(`.github/workflows/maven-publish.yml`)