### PR TITLE
コードカバレッジを向上させるために pom.xml をリファクタリングします。 KmgString メソッドと KmgDelimiterTypes メソッドを強化します。 KmgStringTest を展開します

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,49 +78,9 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- 複雑度 -->
-        <dependency>
-            <groupId>org.openclover</groupId>
-            <artifactId>clover-maven-plugin</artifactId>
-            <version>4.5.2</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.openclover</groupId>
-                    <artifactId>clover-maven-plugin</artifactId>
-                    <version>4.5.2</version>
-                    <configuration>
-                        <targetPercentage>0%</targetPercentage>
-                        <excludes>
-                            <exclude>**/*Test.java</exclude>
-                        </excludes>
-                        <debug>true</debug>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>clover-setup</id>
-                            <phase>process-sources</phase>
-                            <goals>
-                                <goal>setup</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>clover-report</id>
-                            <phase>test</phase>
-                            <goals>
-                                <goal>aggregate</goal>
-                                <goal>clover</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <!-- Spring Boot Maven Plugin -->
             <plugin>
@@ -169,6 +129,26 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>METHOD</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>TOTALCOUNT</value>
+                                            <maximum>15</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -119,9 +119,15 @@
                 <version>0.8.11</version>
                 <executions>
                     <execution>
+                        <id>default-prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <!-- Eclipseと共有するためのファイル設定 -->
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            <append>true</append>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>report</id>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,39 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.openclover</groupId>
+                    <artifactId>clover-maven-plugin</artifactId>
+                    <version>4.5.2</version>
+                    <configuration>
+                        <targetPercentage>0%</targetPercentage>
+                        <excludes>
+                            <exclude>**/*Test.java</exclude>
+                        </excludes>
+                        <debug>true</debug>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>clover-setup</id>
+                            <phase>process-sources</phase>
+                            <goals>
+                                <goal>setup</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>clover-report</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>aggregate</goal>
+                                <goal>clover</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <!-- Spring Boot Maven Plugin -->
             <plugin>
@@ -135,38 +168,6 @@
                         <phase>test</phase>
                         <goals>
                             <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Cloverレポート用 -->
-            <plugin>
-                <groupId>org.openclover</groupId>
-                <artifactId>clover-maven-plugin</artifactId>
-                <version>4.5.2</version>
-                <configuration>
-                    <targetPercentage>0%</targetPercentage>
-                    <excludes>
-                        <exclude>**/*Test.java</exclude>
-                    </excludes>
-                    <instrumentLambda>false</instrumentLambda>
-                    <debug>true</debug>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>clover-setup</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>setup</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>clover-report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>aggregate</goal>
-                            <goal>clover</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/kmg/core/infrastructure/type/KmgString.java
+++ b/src/main/java/kmg/core/infrastructure/type/KmgString.java
@@ -207,36 +207,7 @@ public class KmgString {
             final char prevChar    = target.charAt(i - 1);
 
             /* アンダースコアを追加するかの判定 */
-            // 現在の文字が大文字で、かつ以下のいずれかの条件を満たす場合に区切りを入れる
-            // 1. 前の文字が小文字
-            // 2. 次の文字が存在し、小文字である（連続する大文字の最後）
-            // アンダースコアを追加するかの判定
-            boolean shouldAddUnderscore = false;
-
-            // 現在の文字が大文字かどうかを確認
-            if (Character.isUpperCase(currentChar)) {
-
-                // 条件1: 前の文字が小文字である
-                if (Character.isLowerCase(prevChar)) {
-
-                    shouldAddUnderscore = true;
-
-                }
-
-                // 条件2: 次の文字が存在し、小文字である
-                else if ((i + 1) < target.length()) {
-
-                    final char nextChar = target.charAt(i + 1);
-
-                    if (Character.isLowerCase(nextChar)) {
-
-                        shouldAddUnderscore = true;
-
-                    }
-
-                }
-
-            }
+            final boolean shouldAddUnderscore = shouldAddUnderscore(target, i, currentChar, prevChar);
 
             // アンダースコアを追加しない場合は次の反復に移る
             if (!shouldAddUnderscore) {
@@ -265,6 +236,63 @@ public class KmgString {
         snakeCaseSb.append(target.substring(pos));
 
         result = snakeCaseSb.toString().toLowerCase();
+
+        return result;
+
+    }
+
+    /**
+     * アンダースコアを追加するかどうかを判定する<br>
+     * <p>
+     * 現在の文字が大文字でない場合は早期リターン
+     * </p>
+     *
+     * @author KenichiroArai
+     * @sine 1.0.0
+     * @version 1.0.0
+     * @param target
+     *                     対象文字列
+     * @param currentIndex
+     *                     現在の位置
+     * @param currentChar
+     *                     現在の文字
+     * @param prevChar
+     *                     前の文字
+     * @return true：アンダースコアを追加する、false：アンダースコアを追加しない
+     */
+    private static boolean shouldAddUnderscore(final String target, final int currentIndex, final char currentChar,
+        final char prevChar) {
+
+        boolean result = false;
+
+        // 現在の文字が大文字でない場合は早期リターン
+        if (!Character.isUpperCase(currentChar)) {
+
+            return result;
+
+        }
+
+        // 条件1: 前の文字が小文字である場合
+        if (Character.isLowerCase(prevChar)) {
+
+            result = true;
+            return result;
+
+        }
+
+        // 条件2: 次の文字が存在し、小文字である場合
+        if ((currentIndex + 1) < target.length()) {
+
+            final char nextChar = target.charAt(currentIndex + 1);
+
+            if (Character.isLowerCase(nextChar)) {
+
+                result = true;
+                return result;
+
+            }
+
+        }
 
         return result;
 

--- a/src/main/java/kmg/core/infrastructure/type/KmgString.java
+++ b/src/main/java/kmg/core/infrastructure/type/KmgString.java
@@ -210,9 +210,35 @@ public class KmgString {
             // 現在の文字が大文字で、かつ以下のいずれかの条件を満たす場合に区切りを入れる
             // 1. 前の文字が小文字
             // 2. 次の文字が存在し、小文字である（連続する大文字の最後）
-            final boolean shouldAddUnderscore = Character.isUpperCase(currentChar) && (Character.isLowerCase(prevChar)
-                || (i + 1 < target.length() && Character.isLowerCase(target.charAt(i + 1))));
+            // アンダースコアを追加するかの判定
+            boolean shouldAddUnderscore = false;
 
+            // 現在の文字が大文字かどうかを確認
+            if (Character.isUpperCase(currentChar)) {
+
+                // 条件1: 前の文字が小文字である
+                if (Character.isLowerCase(prevChar)) {
+
+                    shouldAddUnderscore = true;
+
+                }
+
+                // 条件2: 次の文字が存在し、小文字である
+                else if ((i + 1) < target.length()) {
+
+                    final char nextChar = target.charAt(i + 1);
+
+                    if (Character.isLowerCase(nextChar)) {
+
+                        shouldAddUnderscore = true;
+
+                    }
+
+                }
+
+            }
+
+            // アンダースコアを追加しない場合は次の反復に移る
             if (!shouldAddUnderscore) {
 
                 continue;

--- a/src/main/java/kmg/core/infrastructure/type/KmgString.java
+++ b/src/main/java/kmg/core/infrastructure/type/KmgString.java
@@ -192,6 +192,7 @@ public class KmgString {
         if (target.length() == 1) {
             // 一文字の場合
 
+            result = target.toLowerCase();
             return result;
 
         }
@@ -202,30 +203,34 @@ public class KmgString {
 
         for (int i = 1; i < target.length(); ++i) {
 
-            // ローケースか
-            final boolean isLowerCase = Character.isLowerCase(target.charAt(i));
+            final char currentChar = target.charAt(i);
+            final char prevChar    = target.charAt(i - 1);
 
-            if (isLowerCase) {
-                // ローケースの場合
+            /* アンダースコアを追加するかの判定 */
+            // 現在の文字が大文字で、かつ以下のいずれかの条件を満たす場合に区切りを入れる
+            // 1. 前の文字が小文字
+            // 2. 次の文字が存在し、小文字である（連続する大文字の最後）
+            final boolean shouldAddUnderscore = Character.isUpperCase(currentChar) && (Character.isLowerCase(prevChar)
+                || (i + 1 < target.length() && Character.isLowerCase(target.charAt(i + 1))));
+
+            if (!shouldAddUnderscore) {
 
                 continue;
 
             }
 
-            // スネークケースの文字列があるか
+            /* アンダースコアの追加 */
             if (snakeCaseSb.length() != 0) {
-                // ある場合
 
-                // 区切りを入れる
                 snakeCaseSb.append('_');
 
             }
-
             snakeCaseSb.append(target.substring(pos, i));
             pos = i;
 
         }
 
+        /* 残りの部分を追加 */
         if (snakeCaseSb.length() != 0) {
 
             snakeCaseSb.append('_');

--- a/src/main/java/kmg/core/infrastructure/types/KmgDelimiterTypes.java
+++ b/src/main/java/kmg/core/infrastructure/types/KmgDelimiterTypes.java
@@ -275,7 +275,7 @@ public enum KmgDelimiterTypes implements Supplier<String> {
 
         }
 
-        if (sb.length() > 0) {
+        if (sb.length() > 1) {
 
             result = sb.substring(0, sb.length() - 1).toString();
 
@@ -312,9 +312,8 @@ public enum KmgDelimiterTypes implements Supplier<String> {
         // リストが渡された場合は配列に変換
         Object[] targetArray = targets;
 
-        if (targets.length == 1 && targets[0] instanceof List<?>) {
+        if ((targets.length == 1) && (targets[0] instanceof final List<?> list)) {
 
-            List<?> list = (List<?>) targets[0];
             targetArray = list.toArray();
 
         }
@@ -336,7 +335,7 @@ public enum KmgDelimiterTypes implements Supplier<String> {
 
         }
 
-        if (sb.length() > 0) {
+        if (sb.length() > 1) {
 
             result = sb.substring(0, sb.length() - 1).toString();
 

--- a/src/main/java/kmg/core/infrastructure/types/KmgDelimiterTypes.java
+++ b/src/main/java/kmg/core/infrastructure/types/KmgDelimiterTypes.java
@@ -309,13 +309,23 @@ public enum KmgDelimiterTypes implements Supplier<String> {
 
         }
 
+        // リストが渡された場合は配列に変換
+        Object[] targetArray = targets;
+
+        if (targets.length == 1 && targets[0] instanceof List<?>) {
+
+            List<?> list = (List<?>) targets[0];
+            targetArray = list.toArray();
+
+        }
+
         final StringBuilder sb = new StringBuilder();
 
-        for (final Object target : targets) {
+        for (final Object target : targetArray) {
 
             if (target == null) {
 
-                sb.append(target);
+                sb.append("null");
 
             } else {
 

--- a/src/main/java/kmg/core/infrastructure/types/KmgDelimiterTypes.java
+++ b/src/main/java/kmg/core/infrastructure/types/KmgDelimiterTypes.java
@@ -245,8 +245,6 @@ public enum KmgDelimiterTypes implements Supplier<String> {
      */
     public String join(final Object... targets) {
 
-        // TODO KenichiroArai 2021/05/01 ストリーム形式を検討する。
-
         String result = null;
 
         final StringBuilder sb = new StringBuilder();
@@ -316,8 +314,6 @@ public enum KmgDelimiterTypes implements Supplier<String> {
      * @return 結合する文字列にデリミタを付加した文字列
      */
     public String joinAll(final Object... targets) {
-
-        // TODO KenichiroArai 2021/05/01 ストリーム形式を検討する。
 
         String result = null;
 

--- a/src/main/java/kmg/core/infrastructure/types/KmgDelimiterTypes.java
+++ b/src/main/java/kmg/core/infrastructure/types/KmgDelimiterTypes.java
@@ -233,7 +233,8 @@ public enum KmgDelimiterTypes implements Supplier<String> {
     /**
      * 結合する文字列にデリミタを付加して文字列を返す<br>
      * <p>
-     * 但し、結合する文字列がnullまたは空文字の場合は結合しない
+     * 結合する文字列にnullまたは空文字があるの場合はその結合する文字列を含めない。<br>
+     * 結合する文字列がnullの場合は空文字を返す。<br>
      * </p>
      *
      * @author KenichiroArai
@@ -245,7 +246,13 @@ public enum KmgDelimiterTypes implements Supplier<String> {
      */
     public String join(final Object... targets) {
 
-        String result = null;
+        String result = KmgString.EMPTY;
+
+        if (targets == null) {
+
+            return result;
+
+        }
 
         final StringBuilder sb = new StringBuilder();
 
@@ -279,31 +286,10 @@ public enum KmgDelimiterTypes implements Supplier<String> {
     }
 
     /**
-     * 結合する文字列リストにデリミタを付加して文字列を返す<br>
-     * <p>
-     * 結合する文字列がnullまたは空文字の場合はそのまま結合する
-     * </p>
-     *
-     * @author KenichiroArai
-     * @sine 1.0.0
-     * @version 1.0.0
-     * @param <T>
-     *                   結合する文字列の型
-     * @param targetList
-     *                   結合する文字列リスト
-     * @return 結合する文字列リストにデリミタを付加した文字列
-     */
-    public <T> String joinAll(final List<T> targetList) {
-
-        final String result = this.joinAll(targetList.toArray(new Object[0]));
-        return result;
-
-    }
-
-    /**
      * 結合する文字列にデリミタを付加して文字列を返す<br>
      * <p>
-     * 結合する文字列がnullまたは空文字の場合はそのまま結合する
+     * 結合する文字列にnullまたは空文字があるの場合はそのまま結合する<br>
+     * 結合する文字列がnullの場合は空文字を返す。<br>
      * </p>
      *
      * @author KenichiroArai
@@ -315,7 +301,13 @@ public enum KmgDelimiterTypes implements Supplier<String> {
      */
     public String joinAll(final Object... targets) {
 
-        String result = null;
+        String result = KmgString.EMPTY;
+
+        if ((targets == null) || (targets.length == 0)) {
+
+            return result;
+
+        }
 
         final StringBuilder sb = new StringBuilder();
 

--- a/src/test/java/kmg/core/infrastructure/type/KmgStringTest.java
+++ b/src/test/java/kmg/core/infrastructure/type/KmgStringTest.java
@@ -704,16 +704,79 @@ public class KmgStringTest {
     public void testSnakeCase_singleChar() {
 
         /* 期待値の定義 */
-        final String expected = null;
+        final String expected = "a";
 
         /* 準備 */
-        final String target = "a";
+        final String target = "A";
 
         /* テスト対象の実行 */
         final String actual = KmgString.snakeCase(target);
 
         /* 検証の実施 */
-        Assertions.assertEquals(expected, actual, "1文字の場合、nullを返すべき");
+        Assertions.assertEquals(expected, actual, "1文字の場合、小文字にして1文字を返すべき");
+
+    }
+
+    /**
+     * snakeCase メソッドのテスト - 最後の文字が大文字の場合
+     */
+    @Test
+    @SuppressWarnings("static-method")
+    public void testSnakeCase_lastCharUpperCase() {
+
+        /* 期待値の定義 */
+        final String expected = "aaa_bbb_c";
+
+        /* 準備 */
+        final String target = "aaaBbbC";
+
+        /* テスト対象の実行 */
+        final String actual = KmgString.snakeCase(target);
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expected, actual, "最後の文字が大文字の場合の変換が正しくないです");
+
+    }
+
+    /**
+     * snakeCase メソッドのテスト - 連続する大文字の処理
+     */
+    @Test
+    @SuppressWarnings("static-method")
+    public void testSnakeCase_consecutiveUpperCase() {
+
+        /* 期待値の定義 */
+        final String expected = "aaa_bbb_xml_http";
+
+        /* 準備 */
+        final String target = "aaaBbbXMLHttp";
+
+        /* テスト対象の実行 */
+        final String actual = KmgString.snakeCase(target);
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expected, actual, "連続する大文字の処理が正しくないです");
+
+    }
+
+    /**
+     * snakeCase メソッドのテスト - 既にスネークケース形式の場合
+     */
+    @Test
+    @SuppressWarnings("static-method")
+    public void testSnakeCase_alreadySnakeCase() {
+
+        /* 期待値の定義 */
+        final String expected = "aaa_bbb_ccc";
+
+        /* 準備 */
+        final String target = "aaa_bbb_ccc";
+
+        /* テスト対象の実行 */
+        final String actual = KmgString.snakeCase(target);
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expected, actual, "既にスネークケース形式の場合の処理が正しくないです");
 
     }
 

--- a/src/test/java/kmg/core/infrastructure/type/KmgStringTest.java
+++ b/src/test/java/kmg/core/infrastructure/type/KmgStringTest.java
@@ -842,4 +842,67 @@ public class KmgStringTest {
         Assertions.assertEquals(expected, actual, "toString()の結果が正しくないです");
 
     }
+
+    /**
+     * shouldAddUnderscore メソッドのテスト - 文字列の最後の大文字の場合
+     */
+    @Test
+    @SuppressWarnings("static-method")
+    public void testShouldAddUnderscore_lastUpperCase() {
+
+        /* 期待値の定義 */
+        final String expected = "test_a";
+
+        /* 準備 */
+        final String target = "testA";
+
+        /* テスト対象の実行 */
+        final String actual = KmgString.snakeCase(target);
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expected, actual, "文字列の最後の大文字の場合、アンダースコアが追加されるべき");
+
+    }
+
+    /**
+     * shouldAddUnderscore メソッドのテスト - 次の文字が小文字の場合
+     */
+    @Test
+    @SuppressWarnings("static-method")
+    public void testShouldAddUnderscore_nextCharLowerCase() {
+
+        /* 期待値の定義 */
+        final String expected = "test_abc";
+
+        /* 準備 */
+        final String target = "testAbc";
+
+        /* テスト対象の実行 */
+        final String actual = KmgString.snakeCase(target);
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expected, actual, "次の文字が小文字の場合、アンダースコアが追加されるべき");
+
+    }
+
+    /**
+     * shouldAddUnderscore メソッドのテスト - 次の文字が大文字の場合
+     */
+    @Test
+    @SuppressWarnings("static-method")
+    public void testShouldAddUnderscore_nextCharUpperCase() {
+
+        /* 期待値の定義 */
+        final String expected = "test_abc";
+
+        /* 準備 */
+        final String target = "testABC";
+
+        /* テスト対象の実行 */
+        final String actual = KmgString.snakeCase(target);
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expected, actual, "次の文字が大文字の場合、アンダースコアが追加されるべき");
+
+    }
 }

--- a/src/test/java/kmg/core/infrastructure/types/KmgDelimiterTypesTest.java
+++ b/src/test/java/kmg/core/infrastructure/types/KmgDelimiterTypesTest.java
@@ -449,4 +449,308 @@ public class KmgDelimiterTypesTest {
         Assertions.assertEquals(expected, actual, "PERIODの場合、'.'が返されること");
 
     }
+
+    /**
+     * join メソッドのテスト - 通常の文字列配列を結合する場合
+     */
+    @Test
+    public void testJoin_normalCase() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a,b,c";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a", "b", "c"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.join((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "通常の文字列配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * join メソッドのテスト - 1つの要素のみの場合
+     */
+    @Test
+    public void testJoin_singleElement() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.join((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "1つの要素の結合結果が一致しません");
+
+    }
+
+    /**
+     * join メソッドのテスト - 空の配列の場合
+     */
+    @Test
+    public void testJoin_emptyArray() {
+
+        /* 期待値の定義 */
+        final String expectedResult = null;
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {};
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.join((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "空配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * join メソッドのテスト - nullを含む配列の場合
+     */
+    @Test
+    public void testJoin_containsNull() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a,c";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a", null, "c"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.join((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "nullを含む配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * join メソッドのテスト - 空文字を含む配列の場合
+     */
+    @Test
+    public void testJoin_containsEmptyString() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a,c";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a", "", "c"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.join((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "空文字を含む配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * join メソッドのテスト - 配列自体がnullの場合
+     */
+    @Test
+    public void testJoin_nullArray() {
+
+        /* 期待値の定義 */
+        final String expectedResult = null;
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = null;
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.join((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "null配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * joinAll メソッドのテスト - 通常の文字列配列を結合する場合
+     */
+    @Test
+    public void testJoinAll_normalCase() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a,b,c";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a", "b", "c"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "通常の文字列配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * joinAll メソッドのテスト - 1つの要素のみの場合
+     */
+    @Test
+    public void testJoinAll_singleElement() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "1つの要素の結合結果が一致しません");
+
+    }
+
+    /**
+     * joinAll メソッドのテスト - 空の配列の場合
+     */
+    @Test
+    public void testJoinAll_emptyArray() {
+
+        /* 期待値の定義 */
+        final String expectedResult = null;
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {};
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "空配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * joinAll メソッドのテスト - nullを含む配列の場合
+     */
+    @Test
+    public void testJoinAll_containsNull() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a,null,c";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a", null, "c"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "nullを含む配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * joinAll メソッドのテスト - 空文字を含む配列の場合
+     */
+    @Test
+    public void testJoinAll_containsEmptyString() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a,,c";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a", "", "c"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "空文字を含む配列の結合結果が一致しません");
+
+    }
+
+    /**
+     * joinAll メソッドのテスト - 配列自体がnullの場合
+     */
+    @Test
+    public void testJoinAll_nullArray() {
+
+        /* 期待値の定義 */
+        final String expectedResult = null;
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = null;
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "null配列の結合結果が一致しません");
+
+    }
 }

--- a/src/test/java/kmg/core/infrastructure/types/KmgDelimiterTypesTest.java
+++ b/src/test/java/kmg/core/infrastructure/types/KmgDelimiterTypesTest.java
@@ -753,4 +753,82 @@ public class KmgDelimiterTypesTest {
         Assertions.assertEquals(expectedResult, actualResult, "null配列の結合結果が一致しません");
 
     }
+
+    /**
+     * joinAll メソッドのテスト - 1文字の要素の場合（文字列長が1以下）
+     */
+    @Test
+    public void testJoinAll_singleCharElement() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "1文字の要素の結合結果が一致しません");
+
+    }
+
+    /**
+     * joinAll メソッドのテスト - 空文字の要素の場合（文字列長が1以下）
+     */
+    @Test
+    public void testJoinAll_emptyStringElement() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            ""
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "空文字の要素の結合結果が一致しません");
+
+    }
+
+    /**
+     * joinAll メソッドのテスト - 複数の1文字要素の場合（文字列長が1より大きい）
+     */
+    @Test
+    public void testJoinAll_multipleSingleCharElements() {
+
+        /* 期待値の定義 */
+        final String expectedResult = "a,b";
+
+        /* 準備 */
+        final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
+        final String[]          testInput  = {
+            "a", "b"
+        };
+
+        /* テスト対象の実行 */
+        final String testResult = testTarget.joinAll((Object[]) testInput);
+
+        /* 検証の準備 */
+        final String actualResult = testResult;
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expectedResult, actualResult, "複数の1文字要素の結合結果が一致しません");
+
+    }
 }

--- a/src/test/java/kmg/core/infrastructure/types/KmgDelimiterTypesTest.java
+++ b/src/test/java/kmg/core/infrastructure/types/KmgDelimiterTypesTest.java
@@ -509,7 +509,7 @@ public class KmgDelimiterTypesTest {
     public void testJoin_emptyArray() {
 
         /* 期待値の定義 */
-        final String expectedResult = null;
+        final String expectedResult = KmgString.EMPTY;
 
         /* 準備 */
         final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
@@ -585,7 +585,7 @@ public class KmgDelimiterTypesTest {
     public void testJoin_nullArray() {
 
         /* 期待値の定義 */
-        final String expectedResult = null;
+        final String expectedResult = KmgString.EMPTY;
 
         /* 準備 */
         final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
@@ -661,7 +661,7 @@ public class KmgDelimiterTypesTest {
     public void testJoinAll_emptyArray() {
 
         /* 期待値の定義 */
-        final String expectedResult = null;
+        final String expectedResult = KmgString.EMPTY;
 
         /* 準備 */
         final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;
@@ -737,7 +737,7 @@ public class KmgDelimiterTypesTest {
     public void testJoinAll_nullArray() {
 
         /* 期待値の定義 */
-        final String expectedResult = null;
+        final String expectedResult = KmgString.EMPTY;
 
         /* 準備 */
         final KmgDelimiterTypes testTarget = KmgDelimiterTypes.COMMA;

--- a/src/test/java/kmg/core/infrastructure/types/KmgTemplateTypesTest.java
+++ b/src/test/java/kmg/core/infrastructure/types/KmgTemplateTypesTest.java
@@ -73,6 +73,26 @@ public class KmgTemplateTypesTest {
     }
 
     /**
+     * getEnum メソッドのテスト - null値の場合
+     */
+    @Test
+    public void testGetEnum_nullValue() {
+
+        /* 期待値の定義 */
+        final KmgTemplateTypes expected = KmgTemplateTypes.NONE;
+
+        /* 準備 */
+        final String testValue = null;
+
+        /* テスト対象の実行 */
+        final KmgTemplateTypes actual = KmgTemplateTypes.getEnum(testValue);
+
+        /* 検証の実施 */
+        Assertions.assertEquals(expected, actual, "null値の場合、NONEが返されること");
+
+    }
+
+    /**
      * getInitValue メソッドのテスト
      */
     @Test


### PR DESCRIPTION
このプル リクエストには、`pom.xml` 構成への大幅な変更と、`KmgString` クラスの `snakeCase` メソッドの改善が含まれています。さらに、`KmgDelimiterTypes` クラスの `join` メソッドが更新され、`KmgStringTest` に新しいテスト ケースが追加されました。

### 構成の変更:

* `pom.xml` から Clover プラグイン構成を削除し、コード カバレッジ レポートを改善するために新しい JaCoCo 構成を追加しました。 [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L81-L87) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L140-R157)

### コードの改善:

* `KmgString` の `snakeCase` メソッドをリファクタリングして、読みやすさと機能性を向上させました。これには `shouldAddUnderscore` ヘルパー メソッドの追加も含まれます。 [[1]](diffhunk://#diff-78147aad374257c67e39973c28f60b0dc48fde190292109ed05a0607a712e259R195) [[2]](diffhunk://#diff-78147aad374257c67e39973c28f60b0dc48fde190292109ed05a0607a712e259L205-R230) [[3]](diffhunk://#diff-78147aad374257c67e39973c28f60b0dc48fde190292109ed05a0607a712e259R244-R300)

### メソッドの更新:

* `KmgDelimiterTypes` の `join` メソッドと `joinAll` メソッドを更新し、null 値と空値をより適切に処理し、必要に応じてリストを配列に変換できるようにしました。 [[1]](diffhunk://#diff-068ce83b456ca077dd5d601292b1cae8e5456703d51dba69243a491f79a9a7c4L236-R237) [[2]](diffhunk://#diff-068ce83b456ca077dd5d601292b1cae8e5456703d51dba69243a491f79a9a7c4L248-R255) [[3]](diffhunk://#diff-068ce83b456ca077dd5d601292b1cae8e5456703d51dba69243a491f79a9a7c4L273-R278) [[4]](diffhunk://#diff-068ce83b456ca077dd5d601292b1cae8e5456703d51dba69243a491f79a9a7c4L283-R292) [[5]](diffhunk://#diff-068ce83b456ca077dd5d601292b1cae8e5456703d51dba69243a491f79a9a7c4L320-R327)

### テストの強化:

* `KmgStringTest` に新しいテストケースを追加し、`snakeCase` メソッドのエッジケースをカバーし、単一の文字、連続する大文字、および既に snake_case になっている文字列の正しい動作を保証しました。 [[1]](diffhunk://#diff-33a455bb8dc742b7a77a81fc598ee157f3978eac256a3ef512b0a162a4d9c036L707-R779) [[2]](diffhunk://#diff-33a455bb8dc742b7a77a81fc598ee157f3978eac256a3ef512b0a162a4d9c036R845-R907)