### PR TITLE
CIワークフローに手動トリガーを追加し、ログディレクトリを作成するステップを追加しました。

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
         branches: ["main"]
     pull_request:
         branches: ["main"]
+    workflow_dispatch:
 
 jobs:
     build:
@@ -23,6 +24,11 @@ jobs:
                   java-version: "21"
                   distribution: "temurin"
                   cache: maven
+
+            - name: Create log directory
+              run: |
+                  sudo mkdir -p /var/log/TSSTS
+                  sudo chmod 777 /var/log/TSSTS
 
             - name: Build with Maven
               run: mvn -B package --file pom.xml


### PR DESCRIPTION
このプル リクエストには、Maven でビルドする前に新しいトリガーを追加してログ ディレクトリを作成するための、`.github/workflows/ci.yml` ファイルの CI ワークフローへの変更が含まれています。最も重要な変更は次のとおりです:

CI ワークフローの改善:

* ワークフローを手動でトリガーできるように、`on:` セクションに `workflow_dispatch` を追加しました。

* Maven ビルド ステップの前に、適切な権限で `/var/log/TSSTS` にログ ディレクトリを作成する手順を追加しました。