### PR TITLE
CIワークフローに依存関係レビューのステップを追加し、高い深刻度の依存関係をチェックするように設定しました。

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,11 @@ jobs:
                   name: coverage-report
                   path: target/site/jacoco/
 
+            - name: Dependency Review
+              uses: actions/dependency-review-action@v3
+              with:
+                  fail-on-severity: high
+                  deny-licenses: AGPL-1.0-or-later
+
             - name: Update dependency graph
               uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
このプル リクエストには、セキュリティを強化し、ライセンス要件への準拠を維持するための CI ワークフロー構成の変更が含まれています。

CI ワークフローの機能強化:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR52-R57): `actions/dependency-review-action@v3` を使用して依存関係レビューの手順を追加しました。この手順は、重大度の高い問題では失敗し、AGPL-1.0 以降のタイプのライセンスを拒否するように構成されています。