### PR TITLE
テストカバレッジチェックの実装を改善し、HTMLレポートからカバレッジを取得するように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,9 @@ jobs:
               run: mvn test -Djdk.instrument.traceUsage=true -DargLine="-XX:+EnableDynamicAgentLoading"
 
             - name: Check Test Coverage
-              id: coverage
               run: |
-                  COVERAGE=$(mvn jacoco:report | grep -A 1 "Total.*class" | grep "[0-9]\{1,3\}%" | grep -o "[0-9]\{1,3\}%" | cut -d'%' -f1)
-                  echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
+                  mvn jacoco:report
+                  COVERAGE=$(cat target/site/jacoco/index.html | grep -o 'Total[^%]*%' | grep -o '[0-9]\+' || echo "0")
                   if [ "$COVERAGE" -lt 100 ]; then
                     echo "Test coverage is below 100%. Current coverage: $COVERAGE%"
                     exit 1


### PR DESCRIPTION
このプル リクエストには、テスト カバレッジ チェック プロセスを改善するための `.github/workflows/ci.yml` の CI ワークフロー構成の変更が含まれています。

CI ワークフローの改善:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL35-R37): `id: coverage` を削除し、`jacoco` レポートからカバレッジを抽出するメソッドを更新することで、テスト カバレッジ チェックを簡素化しました。新しいメソッドでは、`grep` を使用して、`jacoco` によって生成された `index.html` ファイルから直接カバレッジ パーセンテージを検索します。