### PR TITLE
依存関係のスナップショットを生成し、GitHub APIを使用して提出するようにCIワークフローを更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,9 @@ jobs:
                   fail-on-severity: high
                   deny-licenses: AGPL-1.0-or-later
 
-            - name: Update dependency graph
-              uses: advanced-security/maven-dependency-submission-action@v2
+            - name: Generate and submit dependency snapshot
+              run: |
+                  mvn dependency:tree -DoutputFile=dependency-tree.txt
+                  gh auth status || echo "GitHub CLI not authenticated"
+                  gh api -X POST /repos/${{ github.repository }}/dependency-graph/snapshots \
+                    -F "snapshot=$(cat dependency-tree.txt)"


### PR DESCRIPTION
このプル リクエストには、依存関係スナップショットの生成と送信の方法を改善するための `.github/workflows/ci.yml` ファイルの変更が含まれています。

依存関係管理の改善:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL57-R62): `advanced-security/maven-dependency-submission-action@v2` の使用を、依存関係ツリーを生成して GitHub 依存関係グラフ API に送信するカスタム スクリプトに置き換えました。