### PR TITLE
CIワークフローでの依存関係スナップショット生成時にGitHubトークンを環境変数として設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,9 @@ jobs:
                   deny-licenses: AGPL-1.0-or-later
 
             - name: Generate and submit dependency snapshot
+              env:
+                  GH_TOKEN: ${{ github.token }}
               run: |
                   mvn dependency:tree -DoutputFile=dependency-tree.txt
-                  gh auth status || echo "GitHub CLI not authenticated"
                   gh api -X POST /repos/${{ github.repository }}/dependency-graph/snapshots \
                     -F "snapshot=$(cat dependency-tree.txt)"


### PR DESCRIPTION
このプル リクエストには、GitHub 認証用の環境変数を追加して CI ワークフローを強化するための `.github/workflows/ci.yml` ファイルの変更が含まれています。

CI ワークフローの強化:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR58-L60): 依存関係スナップショットを送信するときに GitHub 認証を確実に行うために、`GH_TOKEN` 環境変数を追加しました。
