### PR TITLE
テストカバレッジチェックのスクリプトを改善し、依存関係グラフの更新方法を変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
 
             - name: Check Test Coverage
               run: |
-                  mvn jacoco:report
-                  COVERAGE=$(cat target/site/jacoco/index.html | grep -o 'Total[^%]*%' | grep -o '[0-9]\+' || echo "0")
+                  COVERAGE=$(mvn jacoco:report | grep -A 1 "Total.*class" | grep "[0-9]\{1,3\}%" | grep -o "[0-9]\{1,3\}%" | cut -d'%' -f1)
                   if [ "$COVERAGE" -lt 100 ]; then
                     echo "Test coverage is below 100%. Current coverage: $COVERAGE%"
                     exit 1
@@ -54,10 +53,5 @@ jobs:
                   fail-on-severity: high
                   deny-licenses: AGPL-1.0-or-later
 
-            - name: Generate and submit dependency snapshot
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  mvn dependency:tree -DoutputFile=dependency-tree.txt
-                  gh api -X POST /repos/${{ github.repository }}/dependency-graph/snapshots \
-                    -F "snapshot=$(cat dependency-tree.txt)"
+            - name: Update dependency graph
+              uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
このプル リクエストには、テスト カバレッジ チェックと依存関係グラフの更新を改善するための `.github/workflows/ci.yml` ファイルの CI ワークフローの更新が含まれています。最も重要な変更には、テスト カバレッジ計算の変更と、依存関係スナップショットの送信を新しいアクションに置き換えることが含まれます。

CI ワークフローの改善:

* テスト カバレッジ計算を変更して、Maven レポート出力からカバレッジ パーセンテージを直接抽出するようにしました。この変更により、より正確で合理化されたカバレッジ チェックが保証されます。
* 依存関係スナップショットの手動送信を `advanced-security/maven-dependency-submission-action` に置き換えて、依存関係グラフの更新プロセスを自動化および簡素化しました。